### PR TITLE
Add shorthand for setting JSON encoding as default.

### DIFF
--- a/servertest.js
+++ b/servertest.js
@@ -86,3 +86,18 @@ function servertest (server, uri, options, callback) {
 
 
 module.exports = servertest
+
+module.exports.json = function(server, uri, options, callback) {
+  if (typeof options == 'function') {
+    callback = options
+    options  = {}
+  }
+
+  if (!options)
+    options = {}
+
+  if (!options.encoding)
+    options.encoding = 'json'
+
+  return servertest(server, uri, options, callback)
+}

--- a/test.js
+++ b/test.js
@@ -234,3 +234,39 @@ test('uppercasing duplex server', function (t) {
     t.end()
   }))
 })
+
+test('json shorthand', function(t) {
+  var testObj = {
+      date : new Date().toISOString()
+    , num  : 101
+    , str  : 'a string'
+    , obj  : { x: 1 }
+  }
+
+  var server = http.createServer(function (req, res) {
+    res.end(JSON.stringify(testObj))
+  })
+
+  servertest.json(server, '/', function (err, res) {
+    t.ifError(err, 'no error')
+    t.deepEqual(res.body, testObj, 'body content')
+    t.end()
+  })
+})
+
+test('json shorthand with different encoding', function(t) {
+  var server = http.createServer(function (req, res) {
+    t.equal(req.method, 'GET', 'correct method (GET)')
+    t.equal(req.url, '/', 'correct url')
+    res.end('OK')
+  })
+
+  servertest.json(server, '/', { encoding: 'utf8' }, function (err, res) {
+    t.ifError(err, 'no error')
+
+    t.equal(res.statusCode, 200, 'statusCode')
+    t.equal(typeof res.body, 'string', 'body is string')
+    t.equal(res.body.toString(), 'OK', 'body content')
+    t.end()
+  })
+})


### PR DESCRIPTION
A large number of APIs are JSON only: passing {encoding: 'json'} to
every request is likely to get very repetitive.

This patch adds a .json property to the exported servertest function,
which simply sets the encoding to json by default. This does not
strongarm json encoding though, if another encoding is specified in the
request options, that encoding will be honored.

I suspect users will likely want the following pattern, setting json
format on by default at require-time:

``` js
var servertest = require('servertest').json
```

Not sure how to best add this to the readme though.
