### PR TITLE
Prevent server from leaking error handler.

### DIFF
--- a/servertest.js
+++ b/servertest.js
@@ -68,11 +68,13 @@ function servertest (server, uri, options, callback) {
 
     instream.pipe(req)
     req.on('response', onResponse)
-    req.on('end', server.close.bind(server))
-  }).on('error', function (err) {
-    return onReturn(e)
-  })
-  
+    req.on('end', function() {
+      server.close(function() {
+        server.removeListener('error', onReturn)
+      })
+    })
+  }).on('error', onReturn)
+
   function onReturn (err) {
     if (!callback || typeof callback != 'function')
       throw err

--- a/test.js
+++ b/test.js
@@ -253,3 +253,21 @@ test('simple auto-/-prefix', function (t) {
   })
 })
 
+test('does not leak event emitters', function(t) {
+  var server = http.createServer(function (req, res) {
+    res.end('OK')
+  })
+  servertest(server, '/', function (err, res) {
+    var events = Object.keys(server._events)
+    var before = {}
+    events.forEach(function (event) {
+      before[event] = server.listeners(event).length
+    })
+    servertest(server, '/', function (err, res) {
+      events.forEach(function (event) {
+        t.equal(server.listeners(event).length, before[event], 'does not leak ' + event)
+      })
+      t.end()
+    })
+  })
+})


### PR DESCRIPTION
Revealed in warning:

```
(node) warning: possible EventEmitter memory leak detected. 11 listeners added. Use emitter.setMaxListeners() to increase limit.
Trace
    at Server.addListener (events.js:160:15)
    at servertest (/*/*/*/node_modules/servertest/servertest.js:72:6)
```

Could increase listener limit, and it's currently safe because callback is nooped after 1st calling, but the listener probably shouldn't be there regardless.
