### PR TITLE
fix: update error message for node@9

### DIFF
--- a/test.js
+++ b/test.js
@@ -278,7 +278,7 @@ test('attach response to err.response and non-enumerable', function(t) {
   })
   servertest(server, '/', {encoding: 'json'}, function (err, res) {
     t.deepEqual(Object.keys(err), [])
-    t.equal(err.message, 'Unexpected token O')
+    t.equal(err.message, 'Unexpected token O in JSON at position 0')
     t.ok(err.response, 'OK')
     t.end()
   })


### PR DESCRIPTION
This fixes this failing test in node@9

```
# attach response to err.response and non-enumerable
(node:28879) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
ok 73 should be equivalent
not ok 74 should be equal
  ---
    operator: equal
    expected: 'Unexpected token O'
    actual:   'Unexpected token O in JSON at position 0'
    at: onReturn (/private/tmp/servertest/servertest.js:88:5)
  ...
ok 75 OK
```