### PR TITLE
set shorter timeout to prevent node@9 warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "bl": "~1.0.0",
-    "hyperquest": "~1.2.0",
+    "hyperquest": "^2.1.2",
     "reduplexer": "~1.1.0",
     "through2": "~2.0.0"
   },

--- a/servertest.js
+++ b/servertest.js
@@ -22,6 +22,8 @@ function servertest (server, uri, options, callback) {
   if (options.encoding == 'json' && !options.headers['accept'])
       options.headers['accept'] = 'application/json'
 
+  options.timeout = options.timeout || Math.pow(2, 31) - 1
+
   var instream  = through2()
     , outstream = through2()
     , stream    = duplexer(instream, outstream)


### PR DESCRIPTION
This prevents the following warning by using a shorter default timeout for `hyperquest`:

```
(node:56380) TimeoutOverflowWarning: 4294967296000 does not fit into a 32-bit signed integer.
Timer duration was truncated to 2147483647.
```